### PR TITLE
Docker compose for easier development

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/dev/Dockerfile.api
+++ b/dev/Dockerfile.api
@@ -1,0 +1,16 @@
+FROM dmstraub/gramps-webapi:latest-devel
+
+# copy config file
+COPY config.cfg /app/config/
+
+# extract & use Gramps example tree
+ENV GRAMPS_RESOURCES /usr/share/
+RUN cp -r /usr/share/doc/gramps/example/gramps/example.gramps.gz .
+RUN gunzip example.gramps.gz
+RUN gramps -C Example -i example.gramps --config=database.backend:sqlite --config=database.path:/app/.gramps/grampsdb
+RUN rm -rf appcache
+
+ENV HOME /app
+
+# build full-text search index
+RUN python3 -m gramps_webapi  --config /app/config/config.cfg search index-full

--- a/dev/Dockerfile.api
+++ b/dev/Dockerfile.api
@@ -13,4 +13,12 @@ RUN rm -rf appcache
 ENV HOME /app
 
 # build full-text search index
-RUN python3 -m gramps_webapi  --config /app/config/config.cfg search index-full
+RUN python3 -m gramps_webapi --config /app/config/config.cfg search index-full
+
+# add user accounts
+RUN python3 -m gramps_webapi --config /app/config/config.cfg user add --role 4 owner owner
+RUN python3 -m gramps_webapi --config /app/config/config.cfg user add --role 3 editor editor
+RUN python3 -m gramps_webapi --config /app/config/config.cfg user add --role 2 contributor contributor
+RUN python3 -m gramps_webapi --config /app/config/config.cfg user add --role 1 member member
+RUN python3 -m gramps_webapi --config /app/config/config.cfg user add --role 0 guest guest
+RUN python3 -m gramps_webapi --config /app/config/config.cfg user add --role -1 disabled disabled

--- a/dev/Dockerfile.frontend
+++ b/dev/Dockerfile.frontend
@@ -1,0 +1,14 @@
+FROM node:17
+
+RUN mkdir /app
+WORKDIR /app
+
+COPY package.json /app/
+COPY package-lock.json /app/
+
+RUN npm install
+
+COPY . /app/
+
+ENTRYPOINT [ "npm", "run" ]
+CMD ["start"]

--- a/dev/config.cfg
+++ b/dev/config.cfg
@@ -1,0 +1,9 @@
+TREE="Example"
+DISABLE_AUTH=True
+MEDIA_BASE_DIR="/usr/share/doc/gramps/example/gramps/"
+SEARCH_INDEX_DIR="/app/indexdir"
+STATIC_PATH="/app/static"
+EXPORT_DIR="/app/tmp"
+REPORT_DIR="/app/tmp"
+BASE_URL="https://localhost:5555/"
+CORS_ORIGINS="*"

--- a/dev/config.cfg
+++ b/dev/config.cfg
@@ -1,9 +1,7 @@
 TREE="Example"
-DISABLE_AUTH=True
 MEDIA_BASE_DIR="/usr/share/doc/gramps/example/gramps/"
 SEARCH_INDEX_DIR="/app/indexdir"
 STATIC_PATH="/app/static"
-EXPORT_DIR="/app/tmp"
-REPORT_DIR="/app/tmp"
 BASE_URL="https://localhost:5555/"
+SECRET_KEY="not_secret_enough"
 CORS_ORIGINS="*"

--- a/dev/nginx.conf
+++ b/dev/nginx.conf
@@ -1,0 +1,56 @@
+# user nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+
+events {
+     worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+
+    log_format   main '[$time_local] $status '
+    '$request - $upstream_addr '
+    '"$http_user_agent"';
+
+    access_log /dev/stdout  main;
+
+    server {
+        listen 80;
+
+        resolver 127.0.0.11 valid=30s ipv6=off;
+        resolver_timeout 5s;
+
+        location /api {
+            add_header       "Access-Control-Allow-Origin" $http_origin;
+            proxy_redirect   off;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            # WebSocket
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+
+            proxy_pass http://gramps-api:5000;
+        }
+
+        location / {
+            add_header       "Access-Control-Allow-Origin" $http_origin;
+            proxy_redirect   off;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            # WebSocket
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+
+            proxy_pass http://gramps-frontend:8000;
+        }
+    }
+
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,17 +3,27 @@ version: "3.8"
 services:
   gramps-proxy:
     image: nginx
+    container_name: gramps-proxy-dev
     volumes:
       - ./dev/nginx.conf:/etc/nginx/nginx.conf
     ports:
       - "5555:80"
   gramps-api:
-    build: 
+    container_name: gramps-api-dev
+    build:
       context: ./dev
       dockerfile: Dockerfile.api
+    volumes:
+      - gramps_users:/app/users  # persist user database
+      - gramps_db:/root/.gramps/grampsdb  # persist Gramps database
   gramps-frontend:
-    build: 
+    container_name: gramps-frontend-dev
+    build:
       context: .
       dockerfile: ./dev/Dockerfile.frontend
     volumes:
       - ./:/app
+
+volumes:
+  gramps_users:
+  gramps_db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3.8"
+
+services:
+  gramps-proxy:
+    image: nginx
+    volumes:
+      - ./dev/nginx.conf:/etc/nginx/nginx.conf
+    ports:
+      - "5555:80"
+  gramps-api:
+    build: 
+      context: ./dev
+      dockerfile: Dockerfile.api
+  gramps-frontend:
+    build: 
+      context: .
+      dockerfile: ./dev/Dockerfile.frontend
+    volumes:
+      - ./:/app


### PR DESCRIPTION
Added Docker Compose setup for easier development.
The frontend and the api are running in separate docker containers. In order to run them on a single port there is reverse proxy added. The reverse proxy forwards all `/api` request to the `gramps-api` container and all other requests go to the `gramps-frontend` container.

The frontend is running in a dev server that makes development without rebuild possible. It also enables auto reload in the browser. 

