### PR TITLE
Localization of the date in the pedigree card.

### DIFF
--- a/src/components/GrampsjsPedigreeCard.js
+++ b/src/components/GrampsjsPedigreeCard.js
@@ -115,11 +115,17 @@ class GrampsjsPedigreeCard extends LitElement {
               <br />
               <span class="dates">
                 ${this.person?.profile?.birth?.date
-                  ? html`* ${this.person.profile.birth.date}`
+                  ? html`*
+                    ${new Date(
+                      Date.parse(this.person.profile.birth.date)
+                    ).toLocaleDateString()}`
                   : ''}
                 <br />
                 ${this.person?.profile?.death?.date
-                  ? html`† ${this.person.profile.death.date}`
+                  ? html`†
+                    ${new Date(
+                      Date.parse(this.person.profile.death.date)
+                    ).toLocaleDateString()}`
                   : ''}
               </span>
               <div class="more">


### PR DESCRIPTION
The dates shown on the pedigree cards were not localized. This is now done using the toLocaleDateString function of dates.