### PR TITLE
Better estimation of fan chart size

### DIFF
--- a/src/components/GrampsjsFanChart.js
+++ b/src/components/GrampsjsFanChart.js
@@ -51,15 +51,12 @@ class GrampsjsFanChart extends GrampsjsTranslateMixin(LitElement) {
       return ''
     }
     const data = getTree(this.data, handle, this.depth)
-    const radius = this.depth * 60
-    const margin = 5
+    const arcRadius = 60
     return html`
       <div id="container">
         ${FanChart(data, {
-          margin,
-          radius,
-          width: 2 * radius + margin,
-          height: 2 * radius + margin,
+          depth: this.depth,
+          arcRadius,
         })}
       </div>
     `


### PR DESCRIPTION
Pretty similar to #184, although here it is a bit easier to get the actual sizes

Instead of assuming that the fan chart is a perfect circle of radius 60 * <ancestor generations> + 30, this calculates the bounding box of the ancestor arcs that are actually drawn.

Before:

https://user-images.githubusercontent.com/4743325/221392267-66532cd2-f0af-4c4c-b75f-797245253c2f.mov

After:

https://user-images.githubusercontent.com/4743325/221392274-c85fdac9-b4b8-431c-9127-b5608bde5a62.mov



