### PR TITLE
Add information to map popups

### DIFF
--- a/src/components/GrampsjsMapMarker.js
+++ b/src/components/GrampsjsMapMarker.js
@@ -1,18 +1,28 @@
+import '@material/mwc-circular-progress'
+import '@material/mwc-list'
+
 import {html, LitElement} from 'lit'
 import {mdiMapMarker} from '@mdi/js'
+
 import {Marker, Icon} from '../../node_modules/leaflet/dist/leaflet-src.esm.js'
 import {iconDataUrl} from '../icons.js'
+import {apiGet} from '../api.js'
+import {GrampsjsTranslateMixin} from '../mixins/GrampsjsTranslateMixin.js'
 
-class GrampsjsMapMarker extends LitElement {
+const EVENT_ICONS = {
+  Birth: '*',
+  Death: '†',
+  Marriage: 'join_full',
+}
+
+class GrampsjsMapMarker extends GrampsjsTranslateMixin(LitElement) {
   render() {
     return html` <link rel="stylesheet" href="leaflet.css" /> `
   }
 
   static get properties() {
     return {
-      latitude: {type: Number},
-      longitude: {type: Number},
-      popupLabel: {type: String},
+      placeData: {type: Object},
       markerId: {type: String},
       opacity: {type: Number},
       size: {type: Number},
@@ -46,15 +56,36 @@ class GrampsjsMapMarker extends LitElement {
       iconAnchor: [this.size / 2, this.size],
       popupAnchor: [0, -this.size],
     })
-    this._marker = new Marker([this.latitude, this.longitude], {
-      opacity: this.opacity,
-      icon,
-    })
+    this._marker = new Marker(
+      [this.placeData.profile.lat, this.placeData.profile.long],
+      {
+        opacity: this.opacity,
+        icon,
+      }
+    )
     this._marker.addTo(this._map)
-    this._marker.on('click', this.clickHandler.bind(this))
-    if (this.popupLabel !== '') {
-      this._marker.bindPopup(this.popupLabel)
-    }
+    this._marker.on('dblclick', this.clickHandler.bind(this))
+    this._marker.on('click', this.popupLoader.bind(this))
+    this.popupHeader = `
+      <a href='place/${this.placeData.profile.gramps_id}'>
+        <h1 style='display:inline-block;text-decoration:underline;vertical-align:top;'>
+          ${this.placeData.profile.name}
+        </h1>
+      </a>
+      ${
+        this.placeData.profile.parent_places?.length > 0 &&
+        `<br />
+          <h2>
+            ${this.placeData.profile.parent_places
+              .map(
+                place => `<a href='place/${place.gramps_id}'>${place.name}</a>`
+              )
+              .join(', ')}
+          </h2>
+        `
+      }
+    `
+    this._marker.bindPopup(this.popupHeader, {maxWidth: 360})
   }
 
   clickHandler() {
@@ -63,12 +94,95 @@ class GrampsjsMapMarker extends LitElement {
         bubbles: true,
         composed: true,
         detail: {
-          latitude: this.latitude,
-          longitude: this.longitude,
+          latitude: this.placeData.profile.lat,
+          longitude: this.placeData.profile.long,
           markerId: this.markerId,
         },
       })
     )
+  }
+
+  popupLoader(event) {
+    const popup = event.target.getPopup()
+
+    // Add a spinner to the end of the popup while we get more detailed place data
+    popup.setContent(
+      `${this.popupHeader}<mwc-circular-progress indeterminate />`
+    )
+
+    // URL for more detailed place data
+    const url = `/api/places/?gramps_id=${
+      this.placeData.profile.gramps_id
+    }&backlinks=true&extend=all&locale=${
+      this.strings?.__lang__ || 'en'
+    }&profile=all`
+
+    // Fetch more detailed data and then update the popup content again
+    apiGet(url).then(result => {
+      const content = GrampsjsMapMarker.renderPopup(this.popupHeader, result)
+      popup.setContent(content)
+    })
+  }
+
+  static renderPopup(header, placesResult) {
+    const extendedLocationData = placesResult?.data?.[0]
+    const extendedContent = placesResult?.data?.[0]?.extended
+    let content = header
+    // add notes
+    if (extendedContent?.notes?.length > 0) {
+      content += extendedContent.notes
+        .map(note => `<p>${note?.text?.string}</p>`)
+        .join('')
+    }
+    // add events
+    content += GrampsjsMapMarker.renderEvents(extendedLocationData)
+    // Prepend with a image if present
+    if (extendedContent?.media?.length > 0) {
+      const imgData = extendedContent.media[0]
+      content = `
+        <grampsjs-img
+          handle="${imgData.handle}"
+          size="64"
+          displayHeight="64"
+          .rect="${[]}"
+          square
+          circle
+          mime="${imgData.mime}"
+        ></grampsjs-img>
+      ${content}`
+    }
+    return content
+  }
+
+  static renderEvents(extendedLocationData) {
+    if (extendedLocationData?.profile?.references?.event?.length > 0) {
+      return `
+        <hr style="min-width:360px" />
+        <mwc-list style="max-height:180px;overflow-y:auto">
+          ${extendedLocationData.profile.references.event
+            .sort((eventA, eventB) => eventA.date.localeCompare(eventB.date))
+            .map((eventData, index) =>
+              GrampsjsMapMarker.renderEvent(
+                eventData,
+                extendedLocationData.extended?.backlinks?.event?.[index]
+                  ?.gramps_id
+              )
+            )
+            .join('')}</mwc-list>`
+    }
+    return ''
+  }
+
+  static renderEvent(eventData, grampsId) {
+    const icon = EVENT_ICONS[eventData.type] ?? 'event'
+
+    return `<a href="/event/${grampsId}" style="text-decoration:none">
+      <mwc-list-item twoline graphic="avatar" title="${eventData.summary}">
+        <span>${eventData.summary}</span>
+        <span slot="secondary">${eventData.date || '~'}</span>
+        <mwc-icon slot="graphic">${icon}</mwc-icon>
+      </mwc-list-item>
+    </a>`
   }
 
   disconnectedCallback() {

--- a/src/views/GrampsjsViewMap.js
+++ b/src/views/GrampsjsViewMap.js
@@ -206,14 +206,12 @@ export class GrampsjsViewMap extends GrampsjsView {
       }
       const highlighted = this._handlesHighlight.includes(obj.handle)
       return html` <grampsjs-map-marker
-        latitude="${obj.profile.lat}"
-        longitude="${obj.profile.long}"
+        .placeData="${obj}"
+        .strings=${this.strings}
         size="${highlighted ? 48 : 32}"
         opacity="${!highlighted && this._handlesHighlight.length > 0
           ? 0.55
           : 0.9}"
-        popupLabel="<a href='place/${obj.profile.gramps_id}'>${obj.profile
-          .name}</a>"
         @marker:clicked="${() => this._handleMarkerClick(obj)}"
       ></grampsjs-map-marker>`
     })


### PR DESCRIPTION
This adds the location parent list, an image, any notes and a scrollable list of events that happened in that place to the place-popups on the map:

<img width="523" alt="Screenshot 2023-02-26 at 3 49 22 PM" src="https://user-images.githubusercontent.com/4743325/221436415-24b86168-208a-43ff-9fb8-dc4f3d7aba2f.png">

Haven't really used lit before, so some of the interactions between it and the leaflet API (expecting `popup.setContent(<some HTML string>)`) are a bit awkward - didn't render any lit elements inside the popup, only regular web components, and couldn't figure out how to get css styles to apply to them, so I just used inline-css. Particularly here, I couldn't figure out how to reuse the `<grampsjs-events>` or `<grampsjs-view-object-notes>` components, so this effectively reimplements them a bit within the GrampsjsMapMarker

Basically, this is a tiny bit hacky. While it works quite nicely with my initial setup, I don't know whether it makes sense to put into the main branch