### PR TITLE
Use task queue for exporter if available

### DIFF
--- a/src/SharedStyles.js
+++ b/src/SharedStyles.js
@@ -220,6 +220,12 @@ export const sharedStyles = css`
     }
   }
 
+  grampsjs-task-progress-indicator.button {
+    position: relative;
+    top: 6px;
+    left: 10px;
+  }
+
   @media (max-width: 768px) {
     :host {
       font-size: 16px;

--- a/src/SharedStyles.js
+++ b/src/SharedStyles.js
@@ -128,6 +128,7 @@ export const sharedStyles = css`
   p {
     margin-top: 1.2em;
     margin-bottom: 1.2em;
+    line-height: 1.6em;
   }
 
   h2 mwc-icon {

--- a/src/api.js
+++ b/src/api.js
@@ -347,10 +347,12 @@ export async function apiPost(
 export function getExporterUrl(id, options) {
   const jwt = localStorage.getItem('access_token')
   const queryParam = new URLSearchParams(options).toString()
-  if (jwt === null) {
-    return `${__APIHOST__}/api/exporters/${id}/file?${queryParam}`
-  }
   return `${__APIHOST__}/api/exporters/${id}/file?jwt=${jwt}&${queryParam}`
+}
+
+export function getExporterDownloadUrl(url) {
+  const jwt = localStorage.getItem('access_token')
+  return `${__APIHOST__}${url}?jwt=${jwt}`
 }
 
 export function getReportUrl(id, options) {

--- a/src/components/GrampsjsTaskProgressIndicator.js
+++ b/src/components/GrampsjsTaskProgressIndicator.js
@@ -2,6 +2,7 @@ import '@material/mwc-circular-progress'
 import '@material/mwc-icon'
 
 import {updateTaskStatus} from '../api.js'
+import {fireEvent} from '../util.js'
 import {GrampsjsProgressIndicator} from './GrampsjsProgressIndicator.js'
 
 export class GrampsjsTaskProgressIndicator extends GrampsjsProgressIndicator {
@@ -9,6 +10,8 @@ export class GrampsjsTaskProgressIndicator extends GrampsjsProgressIndicator {
     return {
       taskId: {type: String},
       pollInterval: {type: Number},
+      hideAfter: {type: Number},
+      status: {type: Object},
     }
   }
 
@@ -17,6 +20,7 @@ export class GrampsjsTaskProgressIndicator extends GrampsjsProgressIndicator {
     this.taskId = ''
     this.pollInterval = 1 // seconds
     this.hideAfter = 10 // seconds
+    this.status = {}
   }
 
   firstUpdated() {
@@ -40,6 +44,7 @@ export class GrampsjsTaskProgressIndicator extends GrampsjsProgressIndicator {
     updateTaskStatus(
       this.taskId,
       status => {
+        this.status = status
         if (status.state === 'SUCCESS') {
           this.setComplete()
         } else if (status.state === 'FAILURE' || status.state === 'REVOKED') {
@@ -53,6 +58,7 @@ export class GrampsjsTaskProgressIndicator extends GrampsjsProgressIndicator {
   setComplete() {
     this.progress = 1
     this.closeAfter()
+    fireEvent(this, 'task:complete', {status: this.status})
   }
 
   setError() {
@@ -61,9 +67,11 @@ export class GrampsjsTaskProgressIndicator extends GrampsjsProgressIndicator {
   }
 
   closeAfter() {
-    setTimeout(() => {
-      this.open = false
-    }, this.hideAfter * 1000)
+    if (this.hideAfter > 0) {
+      setTimeout(() => {
+        this.open = false
+      }, this.hideAfter * 1000)
+    }
   }
 }
 

--- a/src/views/GrampsjsViewExport.js
+++ b/src/views/GrampsjsViewExport.js
@@ -68,7 +68,6 @@ export class GrampsjsViewExport extends GrampsjsView {
           id="downloadanchor"
           >&nbsp;</a
         >
-        ${this._downloadUrl ? getExporterDownloadUrl(this._downloadUrl) : ''}
       </p>
     `
   }

--- a/src/views/GrampsjsViewSettings.js
+++ b/src/views/GrampsjsViewSettings.js
@@ -35,12 +35,6 @@ export class GrampsjsViewSettings extends GrampsjsViewSettingsOnboarding {
         mwc-tab-bar {
           margin-bottom: 30px;
         }
-
-        grampsjs-task-progress-indicator {
-          position: relative;
-          top: 6px;
-          left: 10px;
-        }
       `,
     ]
   }
@@ -105,6 +99,7 @@ export class GrampsjsViewSettings extends GrampsjsViewSettingsOnboarding {
               >${this._('Update search index')}</mwc-button
             >
             <grampsjs-task-progress-indicator
+              class="button"
               id="progress-update-search"
               size="20"
             ></grampsjs-task-progress-indicator>


### PR DESCRIPTION
This uses the task queue for generating exports if available, but also works without it. A status icon shows whether generating the exoprt is still in progress.
