### PR TITLE
Refactor charts, address zoom issues

### DIFF
--- a/src/charts/FanChart.js
+++ b/src/charts/FanChart.js
@@ -77,6 +77,8 @@ export function FanChart(
     arcRadius = 60,
     padding = 3, // separation between arcs
     color = defaultColor,
+    bboxWidth = 800,
+    bboxHeight = 800,
   } = {}
 ) {
   // Create a hierarchical data structure based on the input data
@@ -110,10 +112,12 @@ export function FanChart(
     .innerRadius(d => d.y0)
     .outerRadius(d => d.y0 + 3)
 
-  // scale viewport to match more or less the resolution of the window
-  const svp = window.innerWidth / (width - minX)
+  // center
+  const xOffset = -(bboxWidth - width) / 2
+  const yOffset = -(bboxHeight - height) / 2
+
   const svg = create('svg')
-    .attr('viewBox', [minX * svp, minY, width * svp, height * svp])
+    .attr('viewBox', [minX + xOffset, minY + yOffset, bboxWidth, bboxHeight])
     .call(
       zoom().on('zoom', e =>
         svg.select('#chart-content').attr('transform', e.transform)

--- a/src/charts/TreeChart.js
+++ b/src/charts/TreeChart.js
@@ -44,6 +44,8 @@ export function TreeChart(
     childrenTriangle = true,
     getImageUrl = null,
     orientation = 'LTR',
+    bboxWidth = 800,
+    bboxHeight = 800,
   } = {}
 ) {
   // Create a hierarchical data structure based on the input data
@@ -78,16 +80,21 @@ export function TreeChart(
   const width = trueDepth * boxWidth + (trueDepth - 1) * gapX + 2 * padding
   const [minX, maxX] = getMinMaxX(descendants)
   const height = maxX - minX + boxHeight
-  const yOffset = minX - boxHeight / 2
-  const xOffset =
+  let yOffset = minX - boxHeight / 2
+  let xOffset =
     orientation === 'RTL'
       ? boxWidth / 2 + padding - width
       : -boxWidth / 2 - padding
-
-  // scale viewport to match more or less the resolution of the window
-  const svp = window.innerWidth / (width - xOffset)
+  if (bboxWidth > width) {
+    // center
+    xOffset -= (bboxWidth - width) / 2
+  }
+  if (bboxHeight > height) {
+    // center
+    yOffset -= (bboxHeight - height) / 2
+  }
   const svg = create('svg')
-    .attr('viewBox', [xOffset * svp, yOffset, width * svp, height * svp])
+    .attr('viewBox', [xOffset, yOffset, bboxWidth, bboxHeight])
     .call(
       zoom().on('zoom', e =>
         svg.select('#chart-content').attr('transform', e.transform)

--- a/src/components/GrampsjsChartBase.js
+++ b/src/components/GrampsjsChartBase.js
@@ -1,0 +1,54 @@
+import {html, css, LitElement} from 'lit'
+
+import '@material/mwc-menu'
+import '@material/mwc-list/mwc-list-item'
+
+import {sharedStyles} from '../SharedStyles.js'
+import {GrampsjsTranslateMixin} from '../mixins/GrampsjsTranslateMixin.js'
+
+export class GrampsjsChartBase extends GrampsjsTranslateMixin(LitElement) {
+  static get styles() {
+    return [
+      sharedStyles,
+      css`
+        div#container {
+          display: flex;
+          height: calc(100vh - 165px);
+        }
+      `,
+    ]
+  }
+
+  static get properties() {
+    return {
+      data: {type: Array},
+      containerWidth: {type: Number},
+      containerHeight: {type: Number},
+    }
+  }
+
+  constructor() {
+    super()
+    this.data = []
+    this.containerWidth = -1
+    this.containerHeight = -1
+  }
+
+  render() {
+    return html`<div id="container">${this.renderChart()}</div>`
+  }
+
+  firstUpdated() {
+    const container = this.renderRoot.getElementById('container')
+    this.handleResize()
+    new ResizeObserver(() => this.handleResize()).observe(container)
+  }
+
+  handleResize() {
+    const container = this.renderRoot.getElementById('container')
+    if (container) {
+      this.containerWidth = container.offsetWidth
+      this.containerHeight = container.offsetHeight
+    }
+  }
+}

--- a/src/components/GrampsjsFanChart.js
+++ b/src/components/GrampsjsFanChart.js
@@ -1,28 +1,16 @@
-import {html, css, LitElement} from 'lit'
+import {html, css} from 'lit'
 
-import {sharedStyles} from '../SharedStyles.js'
-import {GrampsjsTranslateMixin} from '../mixins/GrampsjsTranslateMixin.js'
 import {FanChart} from '../charts/FanChart.js'
+import {GrampsjsChartBase} from './GrampsjsChartBase.js'
 import {getPersonByGrampsId, getTree} from '../charts/util.js'
 
-class GrampsjsFanChart extends GrampsjsTranslateMixin(LitElement) {
+class GrampsjsFanChart extends GrampsjsChartBase {
   static get styles() {
     return [
-      sharedStyles,
+      super.styles,
       css`
         svg a {
           text-decoration: none !important;
-        }
-
-        svg {
-          width: 100%;
-          height: calc(100vh - 64px);
-        }
-
-        div#container {
-          display: flex;
-          margin-left: -40px;
-          margin-right: -40px;
         }
       `,
     ]
@@ -32,7 +20,6 @@ class GrampsjsFanChart extends GrampsjsTranslateMixin(LitElement) {
     return {
       grampsId: {type: String},
       depth: {type: Number},
-      data: {type: Array},
     }
   }
 
@@ -40,17 +27,12 @@ class GrampsjsFanChart extends GrampsjsTranslateMixin(LitElement) {
     super()
     this.grampsId = ''
     this.depth = 5
-    this.data = []
-  }
-
-  render() {
-    if (this.data.length === 0 || !this.grampsId) {
-      return ''
-    }
-    return html`${this.renderChart()}`
   }
 
   renderChart() {
+    if (this.data.length === 0 || !this.grampsId) {
+      return ''
+    }
     const {handle} = getPersonByGrampsId(this.data, this.grampsId)
     if (!handle) {
       return ''
@@ -58,12 +40,12 @@ class GrampsjsFanChart extends GrampsjsTranslateMixin(LitElement) {
     const data = getTree(this.data, handle, this.depth)
     const arcRadius = 60
     return html`
-      <div id="container">
-        ${FanChart(data, {
-          depth: this.depth,
-          arcRadius,
-        })}
-      </div>
+      ${FanChart(data, {
+        depth: this.depth,
+        arcRadius,
+        bboxWidth: this.containerWidth,
+        bboxHeight: this.containerHeight,
+      })}
     `
   }
 }

--- a/src/components/GrampsjsTreeChart.js
+++ b/src/components/GrampsjsTreeChart.js
@@ -1,11 +1,10 @@
-import {html, css, LitElement} from 'lit'
+import {html, css} from 'lit'
 
 import '@material/mwc-menu'
 import '@material/mwc-list/mwc-list-item'
 
-import {sharedStyles} from '../SharedStyles.js'
-import {GrampsjsTranslateMixin} from '../mixins/GrampsjsTranslateMixin.js'
 import {TreeChart} from '../charts/TreeChart.js'
+import {GrampsjsChartBase} from './GrampsjsChartBase.js'
 import {
   getDescendantTree,
   getPersonByGrampsId,
@@ -14,24 +13,13 @@ import {
 } from '../charts/util.js'
 import {fireEvent, clickKeyHandler} from '../util.js'
 
-class GrampsjsTreeChart extends GrampsjsTranslateMixin(LitElement) {
+class GrampsjsTreeChart extends GrampsjsChartBase {
   static get styles() {
     return [
-      sharedStyles,
+      super.styles,
       css`
         svg a {
           text-decoration: none !important;
-        }
-
-        svg {
-          width: 100%;
-          height: calc(100vh - 64px);
-        }
-
-        div#container {
-          display: flex;
-          margin-left: -40px;
-          margin-right: -40px;
         }
 
         mwc-menu {
@@ -46,7 +34,6 @@ class GrampsjsTreeChart extends GrampsjsTranslateMixin(LitElement) {
     return {
       grampsId: {type: String},
       depth: {type: Number},
-      data: {type: Array},
       descendants: {type: Boolean},
       gapX: {type: Number},
     }
@@ -56,25 +43,25 @@ class GrampsjsTreeChart extends GrampsjsTranslateMixin(LitElement) {
     super()
     this.grampsId = ''
     this.depth = 5
-    this.data = []
     this.gapX = 30
   }
 
   render() {
-    if (this.data.length === 0 || !this.grampsId) {
-      return ''
-    }
     return html`
       <div
         @pedigree:show-children="${this._handleShowChildren}"
         style="position:relative;"
       >
-        ${this.renderChart()} ${this.renderChildrenMenu()}
+        <div id="container">${this.renderChart()}</div>
+        ${this.renderChildrenMenu()}
       </div>
     `
   }
 
   renderChart() {
+    if (this.data.length === 0 || !this.grampsId) {
+      return ''
+    }
     const {handle} = getPersonByGrampsId(this.data, this.grampsId)
     if (!handle) {
       return ''
@@ -84,17 +71,17 @@ class GrampsjsTreeChart extends GrampsjsTranslateMixin(LitElement) {
       ? getDescendantTree(this.data, handle, this.depth)
       : getTree(this.data, handle, this.depth, false)
     return html`
-      <div id="container">
-        ${TreeChart(data, {
-          depth: this.depth,
-          childrenTriangle: this.descendants
-            ? this._hasParents()
-            : this._hasChildren(),
-          getImageUrl: d => getImageUrl(d?.data?.person || {}, 200),
-          orientation: this.descendants ? 'RTL' : 'LTR',
-          gapX: this.gapX,
-        })}
-      </div>
+      ${TreeChart(data, {
+        depth: this.depth,
+        childrenTriangle: this.descendants
+          ? this._hasParents()
+          : this._hasChildren(),
+        getImageUrl: d => getImageUrl(d?.data?.person || {}, 200),
+        orientation: this.descendants ? 'RTL' : 'LTR',
+        gapX: this.gapX,
+        bboxWidth: this.containerWidth,
+        bboxHeight: this.containerHeight,
+      })}
     `
   }
 

--- a/src/views/GrampsjsViewTree.js
+++ b/src/views/GrampsjsViewTree.js
@@ -49,6 +49,10 @@ export class GrampsjsViewTree extends GrampsjsView {
         mwc-tab[active] {
           opacity: 1;
         }
+
+        #tabs {
+          height: 71px;
+        }
       `,
     ]
   }
@@ -82,7 +86,7 @@ export class GrampsjsViewTree extends GrampsjsView {
       `
     }
     return html`
-      ${this.renderTabs()}
+      <div id="tabs">${this.renderTabs()}</div>
       ${this._currentTabId === 0 ? this._renderPedigree() : ''}
       ${this._currentTabId === 1 ? this._renderDescendantTree() : ''}
       ${this._currentTabId === 2 ? this._renderFan() : ''}

--- a/src/views/GrampsjsViewTreeChartBase.js
+++ b/src/views/GrampsjsViewTreeChartBase.js
@@ -17,6 +17,21 @@ export class GrampsjsViewTreeChartBase extends GrampsjsView {
         :host {
           margin: 0;
           margin-top: -4px;
+          margin-bottom: -25px;
+        }
+
+        #controls {
+          position: absolute;
+          background: rgba(255, 255, 255, 0.9);
+          border-radius: 16px;
+          z-index: 1;
+        }
+
+        #chart {
+          height: calc(100vh - 165px);
+          margin-left: -40px;
+          margin-right: -40px;
+          margin-bottom: -25px;
         }
 
         #controls mwc-icon-button {
@@ -58,12 +73,10 @@ export class GrampsjsViewTreeChartBase extends GrampsjsView {
   }
 
   renderContent() {
-    return html`
-      <div style="position: relative;">
-        <div id="controls">${this.renderControls()}</div>
-        <div id="chart">${this.renderChart()}</div>
-      </div>
-    `
+    return html`<div style="position: relative;">
+      <div id="controls">${this.renderControls()}</div>
+      <div id="chart">${this.renderChart()}</div>
+    </div>`
   }
 
   renderControls() {


### PR DESCRIPTION
@geostag, I refactored the chart code a bit (this should also make it easier with additional zoomable/pannable charts in the future):

- `GrampsjsTreeChart` and `GrampsjsFanChart` inherit from a common base
- The exact dimensions of the container containing the SVG are monitored and stored as properties
- The SVG bounding box uses the exact container dimensions to render with the proper font size on initial render
- The fan chart is always centered upon loading
- The tree charts are centered if they are larger than the viewport
- The controls are now sitting on top of the chart, so we gain some vertical space

Let me know if you're happy with this change.